### PR TITLE
Change the default replica count to zero

### DIFF
--- a/conf/es.cfg.example
+++ b/conf/es.cfg.example
@@ -11,4 +11,4 @@ sar_template_version=02
 
 # comment these out in case you need defaults
 number_of_shards = 1
-number_of_replicas = 1
+number_of_replicas = 0

--- a/lib/backend/conf/sar-index.cfg.example
+++ b/lib/backend/conf/sar-index.cfg.example
@@ -7,7 +7,7 @@ index_prefix = sarjitsu
 index_version = 1
 bulk_action_count = 2000
 number_of_shards = 1
-number_of_replicas = 1
+number_of_replicas = 0
 
 [Grafana]
 dashboard_url = http://172.17.0.4:3000/

--- a/lib/middleware/conf/sar-index.cfg.example
+++ b/lib/middleware/conf/sar-index.cfg.example
@@ -8,7 +8,7 @@ index_prefix = sarjitsu
 index_version = 1
 bulk_action_count = 2000
 number_of_shards = 1
-number_of_replicas = 1
+number_of_replicas = 0
 
 [Grafana]
 ds_name = vos-test


### PR DESCRIPTION
By default we don't want to have any replicas for indices. If one wants
that for production, they have to set it explicitly.
