### PR TITLE
Added development env setup instructions in documentation *refactored*

### DIFF
--- a/lib/backend/activate_dev_mode
+++ b/lib/backend/activate_dev_mode
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Usage:
+# $ . ./activate_dev_mode 
+# or
+# $ source ./activate_dev_mode 
+
+# user_interrupt(){
+#     echo -e "\n\nKeyboard Interrupt detected."
+#     exit
+# }
+
+# trap user_interrupt SIGINT
+# trap user_interrupt SIGTSTP
+
+cd ../../
+
+status=$(docker-compose ps | grep Up  | wc -l)
+
+if [[ $status -gt 6 ]]; then
+    echo "Attempting to kill web container.."
+    docker-compose kill web
+elif [[ $status -lt 6 ]]; then
+    echo "Sarjitsu is not running. Setting up.."
+    docker-compose up -d
+    docker-compose kill web
+fi
+
+docker-compose ps
+
+cd lib/backend/
+
+if [ ! -f conf/sar-index.cfg ]; then
+echo '
+[ElasticSearch]
+host = 0.0.0.0
+port = 9200
+
+[Settings]
+index_prefix = sarjitsu
+index_version = 1
+bulk_action_count = 2000
+number_of_shards = 5
+number_of_replicas = 1
+
+[Grafana]
+dashboard_url = 0.0.0.0:3000
+api_url = http://0.0.0.0:5000/
+' > conf/sar-index.cfg
+fi
+
+# sed 's/DEBUG = False/DEBUG = True/g' src/config.py
+
+# sed -i -e '/^DEBUG/ s/^#*/# /' src/config.py 
+# sed -i -e '/^CFG_PATH/ s/^#*/# /' src/config.py 
+
+echo 'DEBUG = True' > src/config_local.py
+echo 'CFG_PATH = "'$(realpath conf/sar-index.cfg)'"' >> src/config_local.py
+
+packages_count=$(rpm -q python3-devel gpgme-devel gpgme | wc -l)
+if [[ ! $packages_count -eq 3 ]]; then
+    echo "Need sudo permission for installing python3 devel and gpgme/devel packages"
+    sudo dnf -y install python3-devel gpgme-devel gpgme
+fi
+
+host_status=$(grep '0.0.0.0 redis' /etc/hosts)
+if [[ -z $host_status ]]; then 
+    echo "Need sudo to append 0.0.0.0 -- redis to /etc/hosts"
+    echo '0.0.0.0 redis' | sudo tee -a /etc/hosts
+fi
+
+export VOS_CONFIG_PATH="$(realpath conf/sar-index.cfg)"
+
+cd src/
+
+if [ ! -d venv/ ]; then 
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+fi
+
+echo "Now run:"
+echo "$ source venv/bin/activate && ./server.py"
+echo

--- a/lib/backend/src/config.py
+++ b/lib/backend/src/config.py
@@ -1,17 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Statement for enabling the development environment
-DEBUG = False
-# DEBUG = True
-
 import os
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
+# Statement for enabling the development environment
+DEBUG = False
+CFG_PATH = "/opt/sarjitsu/conf/sar-index.cfg"
+
 LOG_FILENAME = 'sarjitsu_app.log'
 LOG_FILESIZE = 10000 # in Bytes
-
-CFG_PATH = "/opt/sarjitsu/conf/sar-index.cfg"
 
 # Application threads. A common general assumption is
 # using 2 per available processor cores - to handle
@@ -55,3 +53,12 @@ HOST = "0.0.0.0"
 
 # The port to run the application from
 PORT = 8000
+
+# override above options with local configs if needed
+try:
+    from config_local import *
+    dev_env = True
+except ImportError:
+    dev_env = False
+except:
+    raise

--- a/lib/backend/src/extract_sa.py
+++ b/lib/backend/src/extract_sa.py
@@ -50,13 +50,15 @@ def extract(sessionID, target, sa_filename):
                                cfg_name=app.config.get('CFG_PATH'),
                                run_unique_id=sessionID,
                                run_md5=sessionID)
+        # import pdb; pdb.set_trace()
+
         if state:
             TSTAMPS['grafana_range_begin'] = beg
             TSTAMPS['grafana_range_end'] = end
     except Exception as E:
         #FIXME: remove if we use the try: approach in future.
-        app.logger.warn("=====Running alternate ES indexing script======")
         app.logger.warn(E)
+        app.logger.warn("=====Running alternate ES indexing script======")
         CMD_INDEXING = ['scripts/vos/analysis/bin/index-sar',
                         SAR_XML_FILEPATH, NODENAME]
         app.logger.info('ES indexing cmd: ' + " ".join(CMD_INDEXING))

--- a/lib/backend/src/scripts/vos/analysis/bin/index-sar
+++ b/lib/backend/src/scripts/vos/analysis/bin/index-sar
@@ -47,7 +47,8 @@ try:
 except IndexError:
     indexname = ''
 
-cfg_name = "/opt/sarjitsu/conf/sar-index.cfg" #os.environ.get('VOS_CONFIG_PATH')
+# cfg_name = "/opt/sarjitsu/conf/sar-index.cfg"
+cfg_name = os.environ.get('VOS_CONFIG_PATH')
 if cfg_name is None:
     print("Need VOS_CONFIG_PATH environment variable defined", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
Adds a script  `lib/backend/activate_dev_mode`, making it easier for developers to setup a test environment outside of a `web` service container.

Also updates README.md with a developer section.

Reworked on top of https://github.com/distributed-system-analysis/sarjitsu/pull/35  