### PR TITLE
Fix the exception handling in upload_processor.py

### DIFF
--- a/lib/backend/src/upload_processor.py
+++ b/lib/backend/src/upload_processor.py
@@ -44,11 +44,11 @@ def begin(target, sessionID, form):
 
     try:
         os.makedirs(target)
-    except FileExistsError:
+    except OSError:
         app.logger.info("Folder %s exists.." % target)
     except Exception as E:
         #FIXME check this part and confirm it
-        return 500
+        return (False, 500)
 
     filename_list = []
     for upload in form.datafile:

--- a/lib/backend/src/upload_processor.py
+++ b/lib/backend/src/upload_processor.py
@@ -42,13 +42,7 @@ def begin(target, sessionID, form):
         _tmp = form.data['graph_types']
         update_cache(sessionID, flag=False, args=_tmp)
 
-    try:
-        os.makedirs(target)
-    except OSError:
-        app.logger.info("Folder %s exists.." % target)
-    except Exception as E:
-        #FIXME check this part and confirm it
-        return (False, 500)
+    os.makedirs(target, exist_ok=True)
 
     filename_list = []
     for upload in form.datafile:


### PR DESCRIPTION
Currently the os.makedirs() returns OSError if the directory
already exists.
In the other case, when we have a general exception, we need
to return a tuple of response as our callers expect from us.

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>