### PR TITLE
Enable alternate data indexing path in Sarjitsu

### DIFF
--- a/lib/backend/conf/sar-index.cfg.example
+++ b/lib/backend/conf/sar-index.cfg.example
@@ -2,6 +2,10 @@
 host =
 port = 9200
 
+[Server]
+host = datasource
+port = 9200
+
 [Settings]
 index_prefix = sarjitsu
 index_version = 1

--- a/lib/backend/src/data_processor.py
+++ b/lib/backend/src/data_processor.py
@@ -24,8 +24,8 @@ def prepare(sessionID, target, sa_filename, q):
         err = p2.stderr
         if err:
             err = err.read().decode()
-            app.logger.error(err)
-            if "Invalid" in err:
+            if "successfully" not in err:
+                app.logger.error(err)
                 app.logger.error("SAR data extraction *failed*!")
                 q[sa_filename] = (None, "Invalid", None)
                 return

--- a/lib/backend/src/extract_sa.py
+++ b/lib/backend/src/extract_sa.py
@@ -63,7 +63,6 @@ def extract(sessionID, target, sa_filename):
     #FIXME: check if call_indexer works everytime. And if it handles errors
     try:
         #FIXME: bad XML ExpatError
-        raise
         state, beg, end = index_sar.call_indexer(file_path=SAR_XML_FILEPATH,
                                _nodename=NODENAME,
                                cfg_name=app.config.get('CFG_PATH'),
@@ -75,7 +74,6 @@ def extract(sessionID, target, sa_filename):
             TSTAMPS['grafana_range_begin'] = beg
             TSTAMPS['grafana_range_end'] = end
     except Exception as E:
-        #FIXME: remove if we use the try: approach in future.
         app.logger.warn(E)
         app.logger.warn("=====Running alternate ES indexing script======")
         CMD_INDEXING = ['scripts/vos/analysis/bin/index-sar',

--- a/lib/backend/src/extract_sa.py
+++ b/lib/backend/src/extract_sa.py
@@ -31,16 +31,34 @@ def extract(sessionID, target, sa_filename):
     CMD_CONVERT.insert(-2, target_file)
 
     #FIXME: check if env in Popen is working fine
-    app.logger.info("spawned CMD: %s" % " ".join(CMD_CONVERT));
-    p1 = subprocess.Popen(CMD_CONVERT, env={'LC_ALL': 'C'},
-                            stdout=open(SAR_XML_FILEPATH, 'w'))
-    p1.wait()
-    app.logger.info("SAR data extraction *completed*!")
+    app.logger.info("spawned CMD: %s" % " ".join(CMD_CONVERT))
+    try:
+        p1 = subprocess.Popen(CMD_CONVERT, env={'LC_ALL': 'C'},
+                              stdout=open(SAR_XML_FILEPATH, 'w'))
+        p1.wait()
+        app.logger.info("SAR data extraction completed!")
+    except ValueError:
+        app.logger.error("Invalid arguments provided to Popen while \
+                          trying to extract SAR data")
+    except OSError as e:
+        app.logger.error("Error forking the process while trying to \
+                          extract the SA data")
+        error_string = "[%s]: %s" % (str(e.errno), e.message)
+        app.logger.error(error_string)
 
     CMD_GREP = ["scripts/detect_nodename", SAR_XML_FILEPATH]
-    p2 = subprocess.Popen(CMD_GREP, stdout=subprocess.PIPE)
-    p2.wait()
-    NODENAME = p2.communicate()[0].decode().replace("\n", "")
+    try:
+        p2 = subprocess.Popen(CMD_GREP, stdout=subprocess.PIPE)
+        p2.wait()
+        NODENAME = p2.communicate()[0].decode().replace("\n", "")
+    except ValueError:
+        app.logger.error("Invalid argument provided to Popen while \
+                         trying to detect nodename")
+    except OSError as e:
+        app.logger.error("Error forking the process while trying to \
+                         detect the nodename")
+        error_string = "[%s]: %s" % (str(e.errno), e.message)
+        app.logger.error(error_string)
 
     #FIXME: check if call_indexer works everytime. And if it handles errors
     try:

--- a/lib/backend/src/scripts/vos/analysis/lib/index_sar.py
+++ b/lib/backend/src/scripts/vos/analysis/lib/index_sar.py
@@ -70,7 +70,7 @@ def gen_action(index, rec, nodename, ts):
         "_index": index,
         "_type": DOCTYPE,
         "_id": md5.hexdigest(),
-        "_timestamp": ts,
+        "timestamp": ts,
         "_source": rec
         }
     return action


### PR DESCRIPTION
The commit adds the following changes:
- Handle the exceptions that can be raised by Popen gracefully
- Replace the _timestamp field to become inline with the latest version of ES in index_sar
- Enable the alternate data indexing path in extract_sa