### PR TITLE
Fix the grafana datasource we create

### DIFF
--- a/lib/middleware/conf/sar-index.cfg.example
+++ b/lib/middleware/conf/sar-index.cfg.example
@@ -13,8 +13,8 @@ sar_template_version=02
 
 [Grafana]
 ds_name = elastic
-pattern = [sarjitsu.sar-]YYYYMMDD
-timeField = recorded_on
+pattern = [sarjitsu.sar-]*
+timeField = ts
 templates_path = /opt/api_server/lib/mappings/
 
 [Api]


### PR DESCRIPTION
We have changed the way how the timestamp field is indexed in elasticsearch. The PR updates the grafana datasource to reflect the changes.

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>